### PR TITLE
Implemented Transactions in dbUpdateTable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,14 +10,14 @@ Depends:
 Imports:
     data.table,
     RMySQL,
-    DBI,
+    DBI (>= 0.5-1),
     magrittr,
     stringr,
     testthat
 License: MIT + file LICENSE
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 5.0.1
+RoxygenNote: 6.0.1
 Collate:
     'dbDeleteRowByKey.R'
     'dbGetKey.R'

--- a/R/dbUpdateTable.R
+++ b/R/dbUpdateTable.R
@@ -17,11 +17,17 @@ dbUpdateTable = function(con, name, dt, verbose = FALSE) {
   # dots = list(...)
   # if("verbose" %in% names(dots)) verbose = dots[["verbose"]]
 
-  dbDeleteRowByKey(con, name, dt)
-  if(verbose) message("Updating")
+  ### Use DBI transcation so that the row is deleated iff the row is then re-inserted
+  DBI::dbWithTransaction(
+    conn = con,
+    code = {
+      dbDeleteRowByKey(con, name, dt)
+      if(verbose) message("Deleating row(s) form database")
 
-  RMySQL::dbWriteTable(con, name, dt, row.names = FALSE, append = TRUE)
-  if(verbose) message("Updated")
+      RMySQL::dbWriteTable(con, name, dt, row.names = FALSE, append = TRUE)
+      if(verbose) message("Writing row(s) to database")
+    }
+  )
 
-  TRUE
+  if(verbose) {TRUE}
 }

--- a/R/dbUpdateTable.R
+++ b/R/dbUpdateTable.R
@@ -6,11 +6,12 @@
 #' @param name A MySQL table name
 #' @param dt A keyed data.table with data to update in \code{name}
 #' @param verbose Print brief progress messages
+#' @param test_kill Is a verable for testing to insure Transaction works
 #'
 #' @include dbDeleteRowByKey.R
 #' @export
 
-dbUpdateTable = function(con, name, dt, verbose = FALSE) {
+dbUpdateTable = function(con, name, dt, verbose = FALSE, test_kill = FALSE) {
 
   # Switches for dots
   # verbose = FALSE
@@ -23,6 +24,9 @@ dbUpdateTable = function(con, name, dt, verbose = FALSE) {
     code = {
       dbDeleteRowByKey(con, name, dt)
       if(verbose) message("Deleating row(s) form database")
+
+      # If Test_kill is true kil the connection to test what happens
+      if (test_kill) {rm(con); gc ()}
 
       RMySQL::dbWriteTable(con, name, dt, row.names = FALSE, append = TRUE)
       if(verbose) message("Writing row(s) to database")

--- a/man/add.Rd
+++ b/man/add.Rd
@@ -14,4 +14,3 @@ add(dt, ...)
 \description{
 Add a row to a data.table - mainly for internal use and testing
 }
-

--- a/man/create.Rd
+++ b/man/create.Rd
@@ -16,4 +16,3 @@ create(model, verbose = TRUE, ...)
 \description{
 Create a query to which when executed will create keyed data.tables in a MySQL database
 }
-

--- a/man/dbDeleteRowByKey.Rd
+++ b/man/dbDeleteRowByKey.Rd
@@ -16,4 +16,3 @@ dbDeleteRowByKey(con, name, dt)
 \description{
 Helper function for dbUpdateTable
 }
-

--- a/man/dbGetKey.Rd
+++ b/man/dbGetKey.Rd
@@ -14,4 +14,3 @@ dbGetKey(con, name)
 \description{
 Get the primary key from a table
 }
-

--- a/man/dbSyncTable.Rd
+++ b/man/dbSyncTable.Rd
@@ -16,4 +16,3 @@ dbSyncTable(con, model, ...)
 \description{
 A convenience function to use create to directly sync a model to the database
 }
-

--- a/man/dbUpdateTable.Rd
+++ b/man/dbUpdateTable.Rd
@@ -4,7 +4,7 @@
 \alias{dbUpdateTable}
 \title{dbUpdateTable}
 \usage{
-dbUpdateTable(con, name, dt, verbose = FALSE)
+dbUpdateTable(con, name, dt, verbose = FALSE, test_kill = FALSE)
 }
 \arguments{
 \item{con}{A MySQL connection}
@@ -14,8 +14,9 @@ dbUpdateTable(con, name, dt, verbose = FALSE)
 \item{dt}{A keyed data.table with data to update in \code{name}}
 
 \item{verbose}{Print brief progress messages}
+
+\item{test_kill}{Is a verable for testing to insure Transaction works}
 }
 \description{
 Update rows of a keyed table via DELETE + INSERT
 }
-

--- a/man/get_sql_type.Rd
+++ b/man/get_sql_type.Rd
@@ -14,4 +14,3 @@ get_sql_type(type, dt = hash_datatypes)
 \description{
 Internal switch between R types and MySQL types
 }
-

--- a/man/grapes-format-grapes.Rd
+++ b/man/grapes-format-grapes.Rd
@@ -19,4 +19,3 @@ parameters <- list(label = "months", april = 4, may = 5, june = 6)
 "\%(label)s: \%(april)d \%(may)d \%(june)d" \%format\% parameters
 
 }
-

--- a/man/hash_datatypes.Rd
+++ b/man/hash_datatypes.Rd
@@ -12,4 +12,3 @@ hash_datatypes
 Current implemented datatype handling
 }
 \keyword{datasets}
-

--- a/tests/testthat/test.dbUpdateTable.R
+++ b/tests/testthat/test.dbUpdateTable.R
@@ -64,8 +64,8 @@ test_that("Update Table can replace data just one row in a table", {
   expect_equal(dt_people, test_4)
 })
 
-####### Tes the ability of transaction
-test_that("Update Table can replace data just one row in a table", {
+####### Test the ability of transaction to stop d
+test_that("Test Transaction will catch a loss of connection, and revert the changess", {
   dt_wrong = data.table::copy(dt_people)[PersonID == 2, Age := Age + 1000000]
 
   # This will not finish runnign and kill the connection db
@@ -83,14 +83,6 @@ test_that("Update Table can replace data just one row in a table", {
 
   expect_equal(dt_people, test_4)
 })
-
-
-
-
-dt_people = dt_people %>% dbUpdateTable::add(5, "LastName5", "Rich",   30)
-dt_people[PersonID == 3, Age := 18]
-
-dbUpdateTable(db, "People", dt_people)
 
 RMySQL::dbRemoveTable(db, "People")
 RMySQL::dbDisconnect(db)

--- a/tests/testthat/test.dbUpdateTable.R
+++ b/tests/testthat/test.dbUpdateTable.R
@@ -1,3 +1,4 @@
+context("dbUpdate table will Update a table, and write over rows")
 # Login details at ~/.my.cnf
 db = RMySQL::dbConnect(RMySQL::MySQL(), group = "MySQL")
 
@@ -20,6 +21,71 @@ dt_people = dt_people %>% dbUpdateTable::add(3, "LastName3", "Meldoy", 26)
 dt_people = dt_people %>% dbUpdateTable::add(4, "LastName4", "Tim",    21)
 
 dbUpdateTable(db, "People", dt_people)
+
+test_that("Update Table can populate a table", {
+  test_1 = suppressWarnings(RMySQL::dbReadTable(db, "People")) %>%
+    data.table::setDT(.) %>%
+    data.table::setkeyv(., dbUpdateTable::dbGetKey(db, "People"))
+
+  expect_equal(dt_people, test_1)
+})
+
+dt_people = dt_people %>% dbUpdateTable::add(5, "LastName5", "Rich",   30)
+dbUpdateTable(db, "People", dt_people)
+
+test_that("Update Table can add data to a table", {
+  test_2 = suppressWarnings(RMySQL::dbReadTable(db, "People")) %>%
+    data.table::setDT(.) %>%
+    data.table::setkeyv(., dbUpdateTable::dbGetKey(db, "People"))
+
+  expect_equal(dt_people, test_2)
+})
+
+dt_people[PersonID == 3, Age := 18]
+dbUpdateTable(db, "People", dt_people)
+
+test_that("Update Table can replace data in a table", {
+  test_3 = suppressWarnings(RMySQL::dbReadTable(db, "People")) %>%
+    data.table::setDT(.) %>%
+    data.table::setkeyv(., dbUpdateTable::dbGetKey(db, "People"))
+
+  expect_equal(dt_people, test_3)
+})
+
+dt_people[PersonID == 2, Age := Age + 1]
+dt_people_one_row = dt_people[PersonID == 2]
+dbUpdateTable(db, "People", dt_people_one_row)
+
+test_that("Update Table can replace data just one row in a table", {
+  test_4 = suppressWarnings(RMySQL::dbReadTable(db, "People")) %>%
+    data.table::setDT(.) %>%
+    data.table::setkeyv(., dbUpdateTable::dbGetKey(db, "People"))
+
+  expect_equal(dt_people, test_4)
+})
+
+####### Tes the ability of transaction
+test_that("Update Table can replace data just one row in a table", {
+  dt_wrong = data.table::copy(dt_people)[PersonID == 2, Age := Age + 1000000]
+
+  # This will not finish runnign and kill the connection db
+  expect_error(
+    dbUpdateTable(db, "People", dt_people_one_row, test_kill = TRUE)
+  )
+
+  # Reinsate db
+  db = RMySQL::dbConnect(RMySQL::MySQL(), group = "MySQL")
+
+  # Insure nothing on the db has changed
+  test_4 = suppressWarnings(RMySQL::dbReadTable(db, "People")) %>%
+    data.table::setDT(.) %>%
+    data.table::setkeyv(., dbUpdateTable::dbGetKey(db, "People"))
+
+  expect_equal(dt_people, test_4)
+})
+
+
+
 
 dt_people = dt_people %>% dbUpdateTable::add(5, "LastName5", "Rich",   30)
 dt_people[PersonID == 3, Age := 18]


### PR DESCRIPTION
The Update Table funtion was not using transactons when deleateing and then updateing records in the db.  This could have lead to the row being delated and then lost if the connection was lost durin the function.  To test is use the code below, killing the connection to the db between the deleat and the write.

```
### Use DBI transcation so that the row is deleated iff the row is then re-inserted
  DBI::dbWithTransaction(
    conn = con,
    code = {
      dbDeleteRowByKey(con, name, dt)
      if(verbose) message("Deleating row(s) form database")

      Sys.sleep(120) # Time to kill the connection

      RMySQL::dbWriteTable(con, name, dt, row.names = FALSE, append = TRUE)
      if(verbose) message("Writing row(s) to database")
    }
  )
```

Also changed the verbose messages to make them even more verboser.