### PR TITLE
dbDeleteRowByKey will safly exist if given empty dt

### DIFF
--- a/R/dbDeleteRowByKey.R
+++ b/R/dbDeleteRowByKey.R
@@ -14,7 +14,8 @@ if (getRversion() >= "2.15.1")  utils::globalVariables(c(".id", "tup"))
 dbDeleteRowByKey = function(con, name, dt) {
 
   # If there are no rows in dt then return, there is nothing to delete.
-  if (dt[, .N == 0 ]) { return() }
+  # Return TRUE to signify lack of error
+  if (dt[, .N == 0 ]) { return(TRUE) }
 
   # Construct main statement
   query = "DELETE FROM %(name)s WHERE (%(pk)s) IN (%(tups)s) ;"

--- a/R/dbDeleteRowByKey.R
+++ b/R/dbDeleteRowByKey.R
@@ -14,7 +14,7 @@ if (getRversion() >= "2.15.1")  utils::globalVariables(c(".id", "tup"))
 dbDeleteRowByKey = function(con, name, dt) {
 
   # If there are no rows in dt then return, there is nothing to delete.
-  if (dt[, .N == 0 ]) {return()}
+  if (dt[, .N == 0 ]) { return() }
 
   # Construct main statement
   query = "DELETE FROM %(name)s WHERE (%(pk)s) IN (%(tups)s) ;"

--- a/R/dbDeleteRowByKey.R
+++ b/R/dbDeleteRowByKey.R
@@ -1,5 +1,5 @@
 # Global variables for data.table column names
-if(getRversion() >= "2.15.1")  utils::globalVariables(c(".id", "tup"))
+if (getRversion() >= "2.15.1")  utils::globalVariables(c(".id", "tup"))
 
 #' Delete rows of a keyed table
 #'
@@ -12,6 +12,10 @@ if(getRversion() >= "2.15.1")  utils::globalVariables(c(".id", "tup"))
 #' @export
 
 dbDeleteRowByKey = function(con, name, dt) {
+
+  # If there are no rows in dt then return, there is nothing to delete.
+  if (dt[, .N == 0 ]) {return()}
+
   # Construct main statement
   query = "DELETE FROM %(name)s WHERE (%(pk)s) IN (%(tups)s) ;"
 
@@ -30,6 +34,7 @@ dbDeleteRowByKey = function(con, name, dt) {
 
   # Insert parameters into query
   query = query %format% list(name = name, pk = str_pk, tups = str_delete_keys)
+
   # Dispatch query
   DBI::dbGetQuery(con, query)
   TRUE
@@ -40,7 +45,7 @@ quote_string_cols = function(dt) {
   col_str_types = col_types[col_types == "character"]
 
   # return if no strings to cast
-  if(length(col_str_types) == 0) return(dt)
+  if (length(col_str_types) == 0) return(dt)
 
   dt[, (names(col_str_types)) := lapply(.SD, quote_string), .SDcols = names(col_str_types)]
   dt

--- a/man/dbDeleteRowByKey.Rd
+++ b/man/dbDeleteRowByKey.Rd
@@ -16,4 +16,3 @@ dbDeleteRowByKey(con, name, dt)
 \description{
 Helper function for dbUpdateTable
 }
-

--- a/tests/testthat/test.dbDeleteRowByKey.R
+++ b/tests/testthat/test.dbDeleteRowByKey.R
@@ -30,5 +30,12 @@ test_that("Exactly 50000 rows are deleted", {
 
 })
 
+test_that("The function will safly exit if given empty dt", {
+
+  # Expect there is no error
+  expect_error(dbDeleteRowByKey(db, "Letters", dt_letters[1 == 0]), NA)
+
+})
+
 RMySQL::dbRemoveTable(db, "Letters")
 RMySQL::dbDisconnect(db)

--- a/tests/testthat/test.dbDeleteRowByKey.R
+++ b/tests/testthat/test.dbDeleteRowByKey.R
@@ -33,7 +33,7 @@ test_that("Exactly 50000 rows are deleted", {
 test_that("The function will safly exit if given empty dt", {
 
   # Expect there is no error
-  expect_error(dbDeleteRowByKey(db, "Letters", dt_letters[1 == 0]), NA)
+  expect_equal(dbDeleteRowByKey(db, "Letters", dt_letters[1 == 0]), NA)
 
 })
 

--- a/tests/testthat/test.dbDeleteRowByKey.R
+++ b/tests/testthat/test.dbDeleteRowByKey.R
@@ -33,7 +33,7 @@ test_that("Exactly 50000 rows are deleted", {
 test_that("The function will safly exit if given empty dt", {
 
   # Expect there is no error
-  expect_equal(dbDeleteRowByKey(db, "Letters", dt_letters[1 == 0]), NA)
+  expect_equal(dbDeleteRowByKey(db, "Letters", dt_letters[1 == 0]), TRUE)
 
 })
 


### PR DESCRIPTION
Before if dbDeleateRowByKey was given an empty data table it would
still try and run, this would then give an MySQL error.  The function
will now test the dimentions of dt and safly return if there are no
rows to deleat.